### PR TITLE
Base properties of a discriminated object are not showed in completion list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
-## 0.0.0 (5 January 2022)
-Initial state
+## Unreleased
+### Bugfix
+- Base properties of a discriminated object are not showed in completion list
+- When there's comma after last array item, HclNode parser falsely think there's one more item.
 
-FEATURES:
+## v0.2.0
+### Enhancements
+- Update bicep types to https://github.com/Azure/bicep-types-az/commit/57f3ecc750648562cf170ef456ef39533872b101
 
-- Completion when input `type`
-- Completion when input `body`, limitation: it only works when use `jsonencode` function to build the JSON
-- Show hint when hover on `type`, `body` and properties defined inside `body`
+## v0.1.0
+### Features
+- Completion of `azapi` resources and data sources
+- Completion of allowed azure resource types when input `type` in `azapi` resources
+- Completion of allowed azure resource properties when input `body` in `azapi` resources, limitation: it only works when use `jsonencode` function to build the JSON
+- Better completion for discriminated object
+- Completion for all required properties
+- Show hint when hover on `azapi` resources
 - Show diagnostics for properties defined inside `body`

--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -152,6 +152,47 @@ func TestCompletion_value(t *testing.T) {
 	}, string(expectRaw))
 }
 
+func TestCompletion_discriminated(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Dir())
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{}))
+	stop := ls.Start(t)
+	defer stop()
+
+	config, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s/main.tf", t.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRaw, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s/expect.json", t.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {},
+		"rootUri": %q,
+		"processId": 12345
+	}`, tmpDir.URI()),
+	})
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method:    "textDocument/didOpen",
+		ReqParams: buildReqParamsTextDocument(string(config), tmpDir.URI()),
+	})
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method:    "textDocument/completion",
+		ReqParams: buildReqParamsCompletion(11, 7, tmpDir.URI()),
+	}, string(expectRaw))
+}
+
 func TestCompletion_prop(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Dir())

--- a/internal/langserver/handlers/testdata/TestCompletion_discriminated/expect.json
+++ b/internal/langserver/handlers/testdata/TestCompletion_discriminated/expect.json
@@ -1,0 +1,159 @@
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "isIncomplete": false,
+    "items": [
+      {
+        "label": "description",
+        "labelDetails": {},
+        "kind": 10,
+        "detail": "description (Optional)",
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `string`  \nThe description of the data flow.\n"
+        },
+        "sortText": "1description",
+        "insertTextFormat": 2,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 6
+            },
+            "end": {
+              "line": 10,
+              "character": 6
+            }
+          },
+          "newText": "description = \"$0\""
+        },
+        "command": {
+          "title": "Suggest",
+          "command": "editor.action.triggerSuggest"
+        }
+      },
+      {
+        "label": "annotations",
+        "labelDetails": {},
+        "kind": 10,
+        "detail": "annotations (Optional)",
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `array`  \nList of tags that can be used for describing the data flow.\n"
+        },
+        "sortText": "1annotations",
+        "insertTextFormat": 2,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 6
+            },
+            "end": {
+              "line": 10,
+              "character": 6
+            }
+          },
+          "newText": "annotations = [$0]"
+        },
+        "command": {
+          "title": "Suggest",
+          "command": "editor.action.triggerSuggest"
+        }
+      },
+      {
+        "label": "folder",
+        "labelDetails": {},
+        "kind": 10,
+        "detail": "folder (Optional)",
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `object`  \nThe folder that this data flow is in. If not specified, Data flow will appear at the root level.\n"
+        },
+        "sortText": "1folder",
+        "insertTextFormat": 2,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 6
+            },
+            "end": {
+              "line": 10,
+              "character": 6
+            }
+          },
+          "newText": "folder = {\n\t$0\n}"
+        },
+        "command": {
+          "title": "Suggest",
+          "command": "editor.action.triggerSuggest"
+        }
+      },
+      {
+        "label": "typeProperties",
+        "labelDetails": {},
+        "kind": 10,
+        "detail": "typeProperties (Optional)",
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `object`  \nFlowlet type properties.\n"
+        },
+        "sortText": "1typeProperties",
+        "insertTextFormat": 2,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 6
+            },
+            "end": {
+              "line": 10,
+              "character": 6
+            }
+          },
+          "newText": "typeProperties = {\n\t$0\n}"
+        },
+        "command": {
+          "title": "Suggest",
+          "command": "editor.action.triggerSuggest"
+        }
+      },
+      {
+        "label": "type",
+        "labelDetails": {},
+        "kind": 10,
+        "detail": "type (Required)",
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `string`  \nType of data flow.\n"
+        },
+        "sortText": "0type",
+        "insertTextFormat": 2,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 6
+            },
+            "end": {
+              "line": 10,
+              "character": 6
+            }
+          },
+          "newText": "type = \"$0\""
+        },
+        "command": {
+          "title": "Suggest",
+          "command": "editor.action.triggerSuggest"
+        }
+      }
+    ]
+  }
+}

--- a/internal/langserver/handlers/testdata/TestCompletion_discriminated/main.tf
+++ b/internal/langserver/handlers/testdata/TestCompletion_discriminated/main.tf
@@ -1,0 +1,14 @@
+resource "azapi_resource" "dataflow" {
+  type = "Microsoft.DataFactory/factories/dataflows@2018-06-01"
+  name = "hengludf0509"
+  parent_id = azurerm_data_factory.test.id
+  body = jsonencode({
+    properties = {
+      type = "Flowlet"
+      typeProperties = {
+
+      }
+
+    }
+  })
+}

--- a/internal/langserver/schema/schema.go
+++ b/internal/langserver/schema/schema.go
@@ -17,7 +17,15 @@ func GetDef(resourceType *types.TypeBase, hclNodes []*parser.HclNode, index int)
 			if discriminator, ok := hclNodes[index-1].Children[t.Discriminator]; ok && discriminator != nil && discriminator.Value != nil {
 				if discriminatorValue := strings.Trim(*discriminator.Value, `"`); len(discriminatorValue) > 0 {
 					if t.Elements[discriminatorValue] != nil && t.Elements[discriminatorValue].Type != nil {
-						resourceType = t.Elements[discriminatorValue].Type
+						selectedDiscriminatedObjectType := &types.DiscriminatedObjectType{
+							Name:           t.Name,
+							Discriminator:  t.Discriminator,
+							BaseProperties: t.BaseProperties,
+							Elements: map[string]*types.TypeReference{
+								discriminatorValue: t.Elements[discriminatorValue],
+							},
+						}
+						return []*types.TypeBase{selectedDiscriminatedObjectType.AsTypeBase()}
 					}
 				}
 			}


### PR DESCRIPTION
To address: https://github.com/Azure/azapi-lsp/issues/40

In a discriminated object, if user specifies the discriminated type, the auto-completion only shows the properties of a certain type, but the base properties are missing.