### PR TITLE
Support syntax which keys are wrapped by quotes.

### DIFF
--- a/internal/langserver/handlers/complete/complete.go
+++ b/internal/langserver/handlers/complete/complete.go
@@ -3,6 +3,7 @@ package complete
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azapi-lsp/internal/langserver/handlers/tfschema"
@@ -64,6 +65,8 @@ func CandidatesAtPos(data []byte, filename string, pos hcl.Pos, logger *log.Logg
 			}
 		}
 	}
+
+	sort.Slice(candidateList, func(i, j int) bool { return candidateList[i].SortText < candidateList[j].SortText })
 	return candidateList
 }
 

--- a/internal/langserver/handlers/complete_test.go
+++ b/internal/langserver/handlers/complete_test.go
@@ -152,6 +152,47 @@ func TestCompletion_value(t *testing.T) {
 	}, string(expectRaw))
 }
 
+func TestCompletion_propWrappedByQuote(t *testing.T) {
+	tmpDir := TempDir(t)
+	InitPluginCache(t, tmpDir.Dir())
+
+	ls := langserver.NewLangServerMock(t, NewMockSession(&MockSessionInput{}))
+	stop := ls.Start(t)
+	defer stop()
+
+	config, err := os.ReadFile(fmt.Sprintf("./testdata/%s/main.tf", t.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRaw, err := os.ReadFile(fmt.Sprintf("./testdata/%s/expect.json", t.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ls.Call(t, &langserver.CallRequest{
+		Method: "initialize",
+		ReqParams: fmt.Sprintf(`{
+		"capabilities": {},
+		"rootUri": %q,
+		"processId": 12345
+	}`, tmpDir.URI()),
+	})
+	ls.Notify(t, &langserver.CallRequest{
+		Method:    "initialized",
+		ReqParams: "{}",
+	})
+	ls.Call(t, &langserver.CallRequest{
+		Method:    "textDocument/didOpen",
+		ReqParams: buildReqParamsTextDocument(string(config), tmpDir.URI()),
+	})
+
+	ls.CallAndExpectResponse(t, &langserver.CallRequest{
+		Method:    "textDocument/completion",
+		ReqParams: buildReqParamsCompletion(9, 11, tmpDir.URI()),
+	}, string(expectRaw))
+}
+
 func TestCompletion_action(t *testing.T) {
 	tmpDir := TempDir(t)
 	InitPluginCache(t, tmpDir.Dir())

--- a/internal/langserver/handlers/testdata/TestCompletion_action/expect.json
+++ b/internal/langserver/handlers/testdata/TestCompletion_action/expect.json
@@ -5,56 +5,6 @@
     "isIncomplete": false,
     "items": [
       {
-        "label": "\"listTestKeys\"",
-        "labelDetails": {},
-        "kind": 12,
-        "documentation": {
-          "kind": "markdown",
-          "value": "Value: `listTestKeys`  \n"
-        },
-        "sortText": "0listTestKeys",
-        "insertTextFormat": 1,
-        "insertTextMode": 2,
-        "textEdit": {
-          "range": {
-            "start": {
-              "line": 2,
-              "character": 10
-            },
-            "end": {
-              "line": 2,
-              "character": 11
-            }
-          },
-          "newText": "\"listTestKeys\""
-        }
-      },
-      {
-        "label": "\"regenerateTestKey\"",
-        "labelDetails": {},
-        "kind": 12,
-        "documentation": {
-          "kind": "markdown",
-          "value": "Value: `regenerateTestKey`  \n"
-        },
-        "sortText": "0regenerateTestKey",
-        "insertTextFormat": 1,
-        "insertTextMode": 2,
-        "textEdit": {
-          "range": {
-            "start": {
-              "line": 2,
-              "character": 10
-            },
-            "end": {
-              "line": 2,
-              "character": 11
-            }
-          },
-          "newText": "\"regenerateTestKey\""
-        }
-      },
-      {
         "label": "\"disableTestEndpoint\"",
         "labelDetails": {},
         "kind": 12,
@@ -105,14 +55,14 @@
         }
       },
       {
-        "label": "\"stop\"",
+        "label": "\"listTestKeys\"",
         "labelDetails": {},
         "kind": 12,
         "documentation": {
           "kind": "markdown",
-          "value": "Value: `stop`  \n"
+          "value": "Value: `listTestKeys`  \n"
         },
-        "sortText": "0stop",
+        "sortText": "0listTestKeys",
         "insertTextFormat": 1,
         "insertTextMode": 2,
         "textEdit": {
@@ -126,7 +76,32 @@
               "character": 11
             }
           },
-          "newText": "\"stop\""
+          "newText": "\"listTestKeys\""
+        }
+      },
+      {
+        "label": "\"regenerateTestKey\"",
+        "labelDetails": {},
+        "kind": 12,
+        "documentation": {
+          "kind": "markdown",
+          "value": "Value: `regenerateTestKey`  \n"
+        },
+        "sortText": "0regenerateTestKey",
+        "insertTextFormat": 1,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 10
+            },
+            "end": {
+              "line": 2,
+              "character": 11
+            }
+          },
+          "newText": "\"regenerateTestKey\""
         }
       },
       {
@@ -152,6 +127,31 @@
             }
           },
           "newText": "\"start\""
+        }
+      },
+      {
+        "label": "\"stop\"",
+        "labelDetails": {},
+        "kind": 12,
+        "documentation": {
+          "kind": "markdown",
+          "value": "Value: `stop`  \n"
+        },
+        "sortText": "0stop",
+        "insertTextFormat": 1,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 10
+            },
+            "end": {
+              "line": 2,
+              "character": 11
+            }
+          },
+          "newText": "\"stop\""
         }
       }
     ]

--- a/internal/langserver/handlers/testdata/TestCompletion_actionBody/expect.json
+++ b/internal/langserver/handlers/testdata/TestCompletion_actionBody/expect.json
@@ -5,36 +5,6 @@
     "isIncomplete": false,
     "items": [
       {
-        "label": "keyType",
-        "labelDetails": {},
-        "kind": 10,
-        "detail": "keyType (Required)",
-        "documentation": {
-          "kind": "markdown",
-          "value": "Type: `string`  \nType of the test key\n"
-        },
-        "sortText": "0keyType",
-        "insertTextFormat": 2,
-        "insertTextMode": 2,
-        "textEdit": {
-          "range": {
-            "start": {
-              "line": 4,
-              "character": 4
-            },
-            "end": {
-              "line": 4,
-              "character": 4
-            }
-          },
-          "newText": "keyType = \"$0\""
-        },
-        "command": {
-          "title": "Suggest",
-          "command": "editor.action.triggerSuggest"
-        }
-      },
-      {
         "label": "required-properties",
         "labelDetails": {},
         "kind": 15,
@@ -58,6 +28,36 @@
             }
           },
           "newText": "keyType = \"$1\"\n"
+        },
+        "command": {
+          "title": "Suggest",
+          "command": "editor.action.triggerSuggest"
+        }
+      },
+      {
+        "label": "keyType",
+        "labelDetails": {},
+        "kind": 10,
+        "detail": "keyType (Required)",
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `string`  \nType of the test key\n"
+        },
+        "sortText": "0keyType",
+        "insertTextFormat": 2,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 4
+            },
+            "end": {
+              "line": 4,
+              "character": 4
+            }
+          },
+          "newText": "keyType = \"$0\""
         },
         "command": {
           "title": "Suggest",

--- a/internal/langserver/handlers/testdata/TestCompletion_apiVersion/expect.json
+++ b/internal/langserver/handlers/testdata/TestCompletion_apiVersion/expect.json
@@ -6,31 +6,6 @@
     "isIncomplete": false,
     "items": [
       {
-        "label": "\"Microsoft.DataFactory/factories@2017-09-01-preview\"",
-        "labelDetails": {},
-        "kind": 12,
-        "documentation": {
-          "kind": "markdown",
-          "value": "Type: `Microsoft.DataFactory/factories`  \nAPI Version: `2017-09-01-preview`"
-        },
-        "sortText": "0002",
-        "insertTextFormat": 1,
-        "insertTextMode": 2,
-        "textEdit": {
-          "range": {
-            "start": {
-              "line": 3,
-              "character": 9
-            },
-            "end": {
-              "line": 3,
-              "character": 43
-            }
-          },
-          "newText": "\"Microsoft.DataFactory/factories@2017-09-01-preview\""
-        }
-      },
-      {
         "label": "\"Microsoft.DataFactory/factories@2018-06-01\"",
         "labelDetails": {},
         "kind": 12,
@@ -53,6 +28,31 @@
             }
           },
           "newText": "\"Microsoft.DataFactory/factories@2018-06-01\""
+        }
+      },
+      {
+        "label": "\"Microsoft.DataFactory/factories@2017-09-01-preview\"",
+        "labelDetails": {},
+        "kind": 12,
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `Microsoft.DataFactory/factories`  \nAPI Version: `2017-09-01-preview`"
+        },
+        "sortText": "0002",
+        "insertTextFormat": 1,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 9
+            },
+            "end": {
+              "line": 3,
+              "character": 43
+            }
+          },
+          "newText": "\"Microsoft.DataFactory/factories@2017-09-01-preview\""
         }
       }
     ]

--- a/internal/langserver/handlers/testdata/TestCompletion_discriminated/expect.json
+++ b/internal/langserver/handlers/testdata/TestCompletion_discriminated/expect.json
@@ -5,15 +5,15 @@
     "isIncomplete": false,
     "items": [
       {
-        "label": "description",
+        "label": "type",
         "labelDetails": {},
         "kind": 10,
-        "detail": "description (Optional)",
+        "detail": "type (Required)",
         "documentation": {
           "kind": "markdown",
-          "value": "Type: `string`  \nThe description of the data flow.\n"
+          "value": "Type: `string`  \nType of data flow.\n"
         },
-        "sortText": "1description",
+        "sortText": "0type",
         "insertTextFormat": 2,
         "insertTextMode": 2,
         "textEdit": {
@@ -27,7 +27,7 @@
               "character": 6
             }
           },
-          "newText": "description = \"$0\""
+          "newText": "type = \"$0\""
         },
         "command": {
           "title": "Suggest",
@@ -58,6 +58,36 @@
             }
           },
           "newText": "annotations = [$0]"
+        },
+        "command": {
+          "title": "Suggest",
+          "command": "editor.action.triggerSuggest"
+        }
+      },
+      {
+        "label": "description",
+        "labelDetails": {},
+        "kind": 10,
+        "detail": "description (Optional)",
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `string`  \nThe description of the data flow.\n"
+        },
+        "sortText": "1description",
+        "insertTextFormat": 2,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 6
+            },
+            "end": {
+              "line": 10,
+              "character": 6
+            }
+          },
+          "newText": "description = \"$0\""
         },
         "command": {
           "title": "Suggest",
@@ -118,36 +148,6 @@
             }
           },
           "newText": "typeProperties = {\n\t$0\n}"
-        },
-        "command": {
-          "title": "Suggest",
-          "command": "editor.action.triggerSuggest"
-        }
-      },
-      {
-        "label": "type",
-        "labelDetails": {},
-        "kind": 10,
-        "detail": "type (Required)",
-        "documentation": {
-          "kind": "markdown",
-          "value": "Type: `string`  \nType of data flow.\n"
-        },
-        "sortText": "0type",
-        "insertTextFormat": 2,
-        "insertTextMode": 2,
-        "textEdit": {
-          "range": {
-            "start": {
-              "line": 10,
-              "character": 6
-            },
-            "end": {
-              "line": 10,
-              "character": 6
-            }
-          },
-          "newText": "type = \"$0\""
         },
         "command": {
           "title": "Suggest",

--- a/internal/langserver/handlers/testdata/TestCompletion_propWrappedByQuote/expect.json
+++ b/internal/langserver/handlers/testdata/TestCompletion_propWrappedByQuote/expect.json
@@ -1,0 +1,39 @@
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "isIncomplete": false,
+    "items": [
+      {
+        "label": "userAssignedIdentity",
+        "labelDetails": {},
+        "kind": 10,
+        "detail": "userAssignedIdentity (Optional)",
+        "documentation": {
+          "kind": "markdown",
+          "value": "Type: `string`  \nThe resource id of the user assigned identity to authenticate to customer's key vault.\n"
+        },
+        "sortText": "1userAssignedIdentity",
+        "insertTextFormat": 2,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 8,
+              "character": 10
+            },
+            "end": {
+              "line": 8,
+              "character": 10
+            }
+          },
+          "newText": "\"userAssignedIdentity\": \"$0\""
+        },
+        "command": {
+          "title": "Suggest",
+          "command": "editor.action.triggerSuggest"
+        }
+      }
+    ]
+  }
+}

--- a/internal/langserver/handlers/testdata/TestCompletion_propWrappedByQuote/main.tf
+++ b/internal/langserver/handlers/testdata/TestCompletion_propWrappedByQuote/main.tf
@@ -1,0 +1,14 @@
+resource "azapi_resource" "test" {
+  name = "acctest1774"
+  parent_id = azurerm_batch_account.test.id
+  type = "Microsoft.DataFactory/factories@2018-06-01"
+  body =  jsonencode({
+    "properties": {
+      "encryption": {
+        "identity": {
+
+        }
+      }
+    }
+  })
+}

--- a/internal/langserver/handlers/testdata/TestCompletion_value/expect.json
+++ b/internal/langserver/handlers/testdata/TestCompletion_value/expect.json
@@ -30,31 +30,6 @@
         }
       },
       {
-        "label": "\"UserAssigned\"",
-        "labelDetails": {},
-        "kind": 12,
-        "documentation": {
-          "kind": "markdown",
-          "value": "Value: `UserAssigned`  \n"
-        },
-        "sortText": "0UserAssigned",
-        "insertTextFormat": 1,
-        "insertTextMode": 2,
-        "textEdit": {
-          "range": {
-            "start": {
-              "line": 6,
-              "character": 13
-            },
-            "end": {
-              "line": 6,
-              "character": 15
-            }
-          },
-          "newText": "\"UserAssigned\""
-        }
-      },
-      {
         "label": "\"SystemAssigned,UserAssigned\"",
         "labelDetails": {},
         "kind": 12,
@@ -77,6 +52,31 @@
             }
           },
           "newText": "\"SystemAssigned,UserAssigned\""
+        }
+      },
+      {
+        "label": "\"UserAssigned\"",
+        "labelDetails": {},
+        "kind": 12,
+        "documentation": {
+          "kind": "markdown",
+          "value": "Value: `UserAssigned`  \n"
+        },
+        "sortText": "0UserAssigned",
+        "insertTextFormat": 1,
+        "insertTextMode": 2,
+        "textEdit": {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 13
+            },
+            "end": {
+              "line": 6,
+              "character": 15
+            }
+          },
+          "newText": "\"UserAssigned\""
         }
       }
     ]


### PR DESCRIPTION
resource "azapi_resource" "test" {
  name = "acctest1774"
  parent_id = azurerm_batch_account.test.id
  type = "Microsoft.DataFactory/factories@2018-06-01"
  body = jsonencode({
    **"properties": {
      "encryption": {}
    }**
  })
}