### PR TITLE
improve init performance

### DIFF
--- a/internal/azure/loader.go
+++ b/internal/azure/loader.go
@@ -35,12 +35,6 @@ func GetAzureSchema() *Schema {
 			return nil
 		}
 	}
-	// preload the first definition
-	for _, resource := range schema.Resources {
-		if len(resource.Definitions) > 0 {
-			_, _ = resource.Definitions[0].GetDefinition()
-		}
-	}
 	return schema
 }
 

--- a/internal/langserver/handlers/tfschema/candidates.go
+++ b/internal/langserver/handlers/tfschema/candidates.go
@@ -60,24 +60,10 @@ func valueCandidates(values []string, r lsp.Range, isOrdered bool) []lsp.Complet
 	return candidates
 }
 
-func resourceTypeCandidates(prefix *string, r lsp.Range) []lsp.CompletionItem {
-	return typeCandidates(prefix, r, false)
-}
-
-func dataSourceTypeCandidates(prefix *string, r lsp.Range) []lsp.CompletionItem {
-	return typeCandidates(prefix, r, true)
-}
-
-func typeCandidates(prefix *string, r lsp.Range, allowReadOnly bool) []lsp.CompletionItem {
+func typeCandidates(prefix *string, r lsp.Range) []lsp.CompletionItem {
 	candidates := make([]lsp.CompletionItem, 0)
 	if prefix == nil || !strings.Contains(*prefix, "@") {
-		for resourceType, resource := range azure.GetAzureSchema().Resources {
-			if len(resource.Definitions) > 0 {
-				def, err := resource.Definitions[0].GetDefinition()
-				if err == nil && def.IsReadOnly() && !allowReadOnly {
-					continue
-				}
-			}
+		for resourceType, _ := range azure.GetAzureSchema().Resources {
 			candidates = append(candidates, lsp.CompletionItem{
 				Label: fmt.Sprintf(`"%s"`, resourceType),
 				Kind:  lsp.ValueCompletion,

--- a/internal/langserver/handlers/tfschema/init.go
+++ b/internal/langserver/handlers/tfschema/init.go
@@ -53,7 +53,7 @@ func init() {
 					Type:                "string <resource-type>@<api-version>",
 					Description:         "Azure Resource Manager type.",
 					CompletionNewText:   `type = "$0"`,
-					ValueCandidatesFunc: resourceTypeCandidates,
+					ValueCandidatesFunc: typeCandidates,
 				},
 
 				{
@@ -252,7 +252,7 @@ func init() {
 					Type:                "string <resource-type>@<api-version>",
 					Description:         "Azure Resource Manager type.",
 					CompletionNewText:   `type = "$0"`,
-					ValueCandidatesFunc: resourceTypeCandidates,
+					ValueCandidatesFunc: typeCandidates,
 				},
 
 				{
@@ -504,7 +504,7 @@ func init() {
 					Type:                "string <resource-type>@<api-version>",
 					Description:         "Azure Resource Manager type.",
 					CompletionNewText:   `type = "$0"`,
-					ValueCandidatesFunc: dataSourceTypeCandidates,
+					ValueCandidatesFunc: typeCandidates,
 				},
 
 				{
@@ -567,7 +567,7 @@ func init() {
 					Type:                "string <resource-type>@<api-version>",
 					Description:         "Azure Resource Manager type.",
 					CompletionNewText:   `type = "$0"`,
-					ValueCandidatesFunc: resourceTypeCandidates,
+					ValueCandidatesFunc: typeCandidates,
 				},
 
 				{
@@ -642,7 +642,7 @@ func init() {
 					Type:                "string <resource-type>@<api-version>",
 					Description:         "Azure Resource Manager type.",
 					CompletionNewText:   `type = "$0"`,
-					ValueCandidatesFunc: resourceTypeCandidates,
+					ValueCandidatesFunc: typeCandidates,
 				},
 
 				{
@@ -717,7 +717,7 @@ func init() {
 					Type:                "string <resource-type>@<api-version>",
 					Description:         "Azure Resource Manager type.",
 					CompletionNewText:   `type = "$0"`,
-					ValueCandidatesFunc: dataSourceTypeCandidates,
+					ValueCandidatesFunc: typeCandidates,
 				},
 
 				{
@@ -764,7 +764,7 @@ func init() {
 					Type:                "string <resource-type>@<api-version>",
 					Description:         "Azure Resource Manager type.",
 					CompletionNewText:   `type = "$0"`,
-					ValueCandidatesFunc: dataSourceTypeCandidates,
+					ValueCandidatesFunc: typeCandidates,
 				},
 
 				{


### PR DESCRIPTION
Previously the extension loads all the type definition during initialization, and this is used to differentiate between the read only types and normal resource types. But this could be really time-consuming, so this PR disables this feature to improve the performance.

Now the initialization only takes 100ms to finish, previously it was 33s.