### PR TITLE
bugfix: resource group's 2024-07-01 api-version is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ ENHANCEMENTS:
 - `azapi` resources/data sources: Update embedded schema to the latest version.
 - Support specifying the provider version used in the migration in the `terraform` block.
 
+BUG FIXES:
+- Fix a bug that resource group's api-version `2024-07-01` is disabled in the provider.
 
 ## v2.3.0
 

--- a/internal/azure/loader.go
+++ b/internal/azure/loader.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/Azure/azapi-lsp/internal/azure/types"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
 var schema *Schema
@@ -50,17 +49,6 @@ func GetApiVersions(resourceType string) []string {
 				res = append(res, v.ApiVersion)
 			}
 		}
-	}
-
-	// TODO: remove the below codes when Resources RP 2024-07-01 is available
-	if strings.EqualFold(resourceType, arm.ResourceGroupResourceType.String()) {
-		temp := make([]string, 0)
-		for _, v := range res {
-			if v != "2024-07-01" {
-				temp = append(temp, v)
-			}
-		}
-		res = temp
 	}
 
 	sort.Strings(res)


### PR DESCRIPTION
fixes https://github.com/Azure/azapi-vscode/issues/55